### PR TITLE
fix: replace geodesy with inline haversine to fix ESM/CJS incompatibi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "onnxruntime-node": "^1.17.0",
     "node-onvif": "^0.1.7",
     "fluent-ffmpeg": "^2.1.3",
-    "geodesy": "^2.4.0",
     "sharp": "^0.33.0"
   },
   "devDependencies": {},

--- a/plugin/gps-calculator.js
+++ b/plugin/gps-calculator.js
@@ -1,4 +1,23 @@
-const LatLon = require('geodesy/latlon-spherical.js');
+// Inline haversine helpers — geodesy v2 is ESM-only and cannot be require()'d
+// from a CommonJS plugin. These formulae are equivalent to geodesy's
+// LatLonSpherical.destinationPoint() on a spherical earth (R = 6371 km).
+const _R = 6371000;
+function _destinationPoint(lat, lon, distMetres, bearingDeg) {
+  const δ = distMetres / _R;
+  const θ = bearingDeg * Math.PI / 180;
+  const φ1 = lat * Math.PI / 180;
+  const λ1 = lon * Math.PI / 180;
+  const sinφ2 = Math.sin(φ1) * Math.cos(δ) + Math.cos(φ1) * Math.sin(δ) * Math.cos(θ);
+  const φ2 = Math.asin(sinφ2);
+  const λ2 = λ1 + Math.atan2(
+    Math.sin(θ) * Math.sin(δ) * Math.cos(φ1),
+    Math.cos(δ) - Math.sin(φ1) * sinφ2
+  );
+  return {
+    lat: φ2 * 180 / Math.PI,
+    lon: ((λ2 * 180 / Math.PI) + 540) % 360 - 180
+  };
+}
 
 class GpsCalculator {
   constructor(app) {
@@ -19,8 +38,7 @@ class GpsCalculator {
     // Bearing: centre of frame = straight ahead; 60° FOV assumption
     const bearing_deg = (boatHeading + ((detection.cx - 0.5) * 60) + 360) % 360;
 
-    const start = new LatLon(boatLat, boatLon);
-    const dest  = start.destinationPoint(distance_m, bearing_deg);
+    const dest = _destinationPoint(boatLat, boatLon, distance_m, bearing_deg);
 
     return {
       lat:         dest.lat,


### PR DESCRIPTION
fix: replace geodesy with inline haversine to fix ESM/CJS incompatibility

geodesy v2 is ESM-only and cannot be require()'d from a CommonJS plugin.
Replace the LatLon.destinationPoint() call with an equivalent inline
haversine formula. Remove geodesy from dependencies.

Fixes #1