### PR TITLE
Add managed FFmpeg container grabber

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ AI-powered forward watch obstacle detection for Signal K. Monitors a bow-mounted
 - Signal K server **v2.23.0 or later** recommended (Node.js ≥ 18)
   - Earlier Signal K versions have an unrelated AIS TCP provider memory leak that causes server instability when AIS is active alongside this plugin
 - A bow-mounted IP camera with RTSP stream (ONVIF cameras auto-discovered)
-- ffmpeg installed on the host (`sudo apt install ffmpeg`)
+- ffmpeg available through one of these modes:
+  - local mode: ffmpeg installed beside Signal K (`sudo apt install ffmpeg`)
+  - container mode: [`signalk-container`](https://github.com/dirkwa/signalk-container) installed and configured with Docker or Podman access
 - Raspberry Pi 4 or better (CPU inference, no GPU required)
 
 ---
@@ -52,12 +54,24 @@ Restart Signal K and enable the plugin in **Admin → Plugin Config → Forward 
 | **Camera IP Address** | — | IP address of your bow camera (e.g. `192.168.1.100`) |
 | **Camera Username** | `admin` | RTSP/ONVIF login username |
 | **Camera Password** | — | RTSP/ONVIF login password |
-| **RTSP URL** | auto | Full RTSP stream URL. If left blank, the plugin runs ONVIF discovery using the IP/user/pass above. Enter manually to skip discovery: `rtsp://user:pass@ip:554/stream1` |
+| **RTSP URL** | auto | Full RTSP stream URL. If left blank, the plugin runs ONVIF discovery using the IP/user/pass above. Enter manually to skip discovery: `rtsp://user:pass@ip:554/stream1`. If the URL has no embedded credentials, the Camera Username and Camera Password fields are applied automatically. |
 | **Detection interval (seconds)** | `300` | How often to grab a frame and run detection. Lower = more CPU. Default 300s is conservative; v0.2.0+ worker thread allows 60s on Raspberry Pi 4 without impacting Signal K. |
+| **FFmpeg execution mode** | `local` | `local` uses ffmpeg installed in the Signal K environment. `container` runs a persistent FFmpeg sidecar through `signalk-container`. |
+| **FFmpeg container image** | `lscr.io/linuxserver/ffmpeg` | Container image used when FFmpeg execution mode is `container`. Advanced users may include a tag, for example `lscr.io/linuxserver/ffmpeg:version-6.1-cli`; when no tag is specified, `latest` is used. |
 | **Alert cooldown (seconds)** | `30` | Minimum time between repeat alerts for the same target type and quadrant. Prevents alarm flooding. |
 | **Enable audio alarm** | `false` | Plays a system beep on detection within 100m. Requires audio output on the host. |
 | **Confidence threshold** | `0.4` | Minimum detection confidence (0–1). Lower = more detections but more false positives. 0.4 is a good starting point. |
 | **Show detections in OpenCPN** | `true` | Sends detections to OpenCPN as AIS targets on the chart. Requires boat GPS. |
+
+### FFmpeg Container Mode
+
+Container mode is intended for Signal K deployments where the server itself runs in Docker or Podman and installing ffmpeg inside the Signal K image is undesirable. Install and enable `signalk-container`, then set **FFmpeg execution mode** to `container`.
+
+Forward Watch starts one persistent managed container named `sk-forward-watch-ffmpeg`. It runs ffmpeg for the lifetime of the plugin, writes the latest RTSP frame to the plugin data directory, and is stopped when the plugin is disabled. The container is not recreated for every frame.
+
+The container gets access to the Signal K config root via `signalkConfigRootMount`, then writes to Forward Watch's own `plugin-config-data/signalk-forward-watch/frames/latest.jpg` path. This keeps the frame file visible to the detector whether Signal K is running bare-metal or inside a container.
+
+If the container keeps running but stops updating `latest.jpg`, Forward Watch treats the frame as stale and restarts the managed FFmpeg container. This handles RTSP sessions that remain alive at Docker level while ffmpeg is no longer producing fresh JPEGs.
 
 ---
 
@@ -213,8 +227,14 @@ A Signal K notification is sent for any detection **within 100m**. One notificat
 
 **No detections, camera not connecting**
 - Check your RTSP URL is correct. Test it with VLC on another device.
-- Make sure ffmpeg is installed: `ffmpeg -version`
+- In local FFmpeg mode, make sure ffmpeg is installed: `ffmpeg -version`
+- In container FFmpeg mode, make sure `signalk-container` is enabled and reports a working Docker or Podman runtime.
 - Check the camera IP is reachable from the Signal K host.
+
+**Container FFmpeg mode starts but no frames appear**
+- Check the Signal K server log with Forward Watch debug enabled. FFmpeg container output is forwarded as `[ffmpeg-container] ...`.
+- Open the `signalk-container` config panel and inspect the `sk-forward-watch-ffmpeg` container logs.
+- If Signal K itself runs in a container, verify the `signalk-container` deployment doctor reports `ok` and can resolve the Signal K container/config root.
 
 **High CPU usage**
 - Increase the detection interval. Default is 300s; v0.2.0+ worker thread allows 60s on Pi 4 without impacting Signal K performance.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const CameraDiscovery = require('./plugin/camera-discovery');
 const RtspGrabber = require('./plugin/rtsp-grabber');
+const ContainerRtspGrabber = require('./plugin/container-rtsp-grabber');
 const Detector = require('./plugin/detector');
 const GpsCalculator = require('./plugin/gps-calculator');
 const SignalkOutput = require('./plugin/signalk-output');
@@ -43,6 +44,17 @@ module.exports = function(app) {
           minimum: 10,
           maximum: 600
         },
+        ffmpeg_mode: {
+          type: 'string',
+          title: 'FFmpeg execution mode',
+          enum: ['local', 'container'],
+          default: 'local'
+        },
+        ffmpeg_container_image: {
+          type: 'string',
+          title: 'FFmpeg container image',
+          default: 'lscr.io/linuxserver/ffmpeg'
+        },
         alert_cooldown: {
           type: 'number',
           title: 'Seconds before re-alerting same target',
@@ -69,11 +81,21 @@ module.exports = function(app) {
       required: ['camera_ip', 'camera_user', 'camera_pass']
     },
 
-    start: async function(options) {
+    start: function(options) {
+      options = options || {};
+      this.startAsync(options).catch((err) => {
+        app.debug('Forward Watch startup failed: ' + err.message);
+        if (app.setPluginError) app.setPluginError('Startup failed: ' + err.message);
+      });
+    },
+
+    startAsync: async function(options) {
       app.debug('Starting Forward Watch plugin');
 
       this.discovery = new CameraDiscovery(app);
-      this.grabber = new RtspGrabber(app);
+      this.grabber = options.ffmpeg_mode === 'container'
+        ? new ContainerRtspGrabber(app, options)
+        : new RtspGrabber(app);
       this.detector = new Detector(app, MODEL_PATH);
       this.gpsCalc = new GpsCalculator(app);
       this.skOutput = new SignalkOutput(app, options);
@@ -90,18 +112,27 @@ module.exports = function(app) {
         const cameras = await this.discovery.scan();
         if (cameras.length > 0) {
           rtspUrl = cameras[0].rtsp_url;
-          app.debug(`Discovered camera: ${rtspUrl}`);
+          app.debug(`Discovered camera: ${redactRtspUrl(rtspUrl)}`);
         } else {
           rtspUrl = await this.discovery.buildRtspUrl(options.camera_ip, options.camera_user, options.camera_pass);
-          app.debug(`Using fallback RTSP URL: ${rtspUrl}`);
+          app.debug(`Using fallback RTSP URL: ${redactRtspUrl(rtspUrl)}`);
         }
       }
+      rtspUrl = addRtspCredentials(rtspUrl, options.camera_user, options.camera_pass);
 
       this.rtspUrl = rtspUrl;
+      if (this.grabber.start) {
+        await this.grabber.start(this.rtspUrl);
+      }
+
       app.debug(`Starting detection loop every ${options.detection_interval}s`);
+      if (app.setPluginStatus) {
+        const mode = options.ffmpeg_mode === 'container' ? 'container FFmpeg' : 'local FFmpeg';
+        app.setPluginStatus(`Running with ${mode}`);
+      }
 
       this.running = false;
-      this.interval = setInterval(async () => {
+      const detectOnce = async () => {
         if (this.running) return; // skip if previous inference still in progress
         this.running = true;
         try {
@@ -133,7 +164,10 @@ module.exports = function(app) {
         } finally {
           this.running = false;
         }
-      }, (options.detection_interval || 300) * 1000);
+      };
+
+      this.interval = setInterval(detectOnce, (options.detection_interval || 300) * 1000);
+      detectOnce();
     },
 
     stop: function() {
@@ -146,3 +180,31 @@ module.exports = function(app) {
 
   return plugin;
 };
+
+function addRtspCredentials(rtspUrl, user, pass) {
+  if (!rtspUrl || !user || !pass) return rtspUrl;
+
+  try {
+    const parsed = new URL(rtspUrl);
+    if (parsed.protocol !== 'rtsp:' && parsed.protocol !== 'rtsps:') return rtspUrl;
+    if (parsed.username || parsed.password) return rtspUrl;
+
+    parsed.username = user;
+    parsed.password = pass;
+    return parsed.toString();
+  } catch (err) {
+    return rtspUrl;
+  }
+}
+
+function redactRtspUrl(rtspUrl) {
+  if (!rtspUrl) return rtspUrl;
+
+  try {
+    const parsed = new URL(rtspUrl);
+    if (parsed.password) parsed.password = '***';
+    return parsed.toString();
+  } catch (err) {
+    return rtspUrl;
+  }
+}

--- a/plugin/container-rtsp-grabber.js
+++ b/plugin/container-rtsp-grabber.js
@@ -1,0 +1,183 @@
+const fs = require('fs');
+const path = require('path');
+
+const CONTAINER_NAME = 'forward-watch-ffmpeg';
+const CONFIG_ROOT_MOUNT = '/signalk-config';
+const FRAME_FILE = 'latest.jpg';
+const PLUGIN_VERSION = require('../package.json').version;
+
+class ContainerRtspGrabber {
+  constructor(app, options) {
+    this.app = app;
+    this.options = options || {};
+    this.containers = null;
+    this.frameDir = path.join(app.getDataDirPath(), 'frames');
+    this.framePath = path.join(this.frameDir, FRAME_FILE);
+    this.frameMaxAgeMs = Math.max((this.options.detection_interval || 1) * 3000, 10000);
+    this.started = false;
+    this.stopped = false;
+    this.rtspUrl = null;
+    this.restartPromise = null;
+  }
+
+  async start(rtspUrl) {
+    this.rtspUrl = rtspUrl;
+    this.stopped = false;
+    fs.mkdirSync(this.frameDir, { recursive: true });
+
+    this.containers = globalThis.__signalk_containerManager;
+    if (!this.containers) {
+      throw new Error('signalk-container plugin is required for container FFmpeg mode');
+    }
+
+    await this.containers.whenReady();
+    if (!this.containers.getRuntime()) {
+      throw new Error('No Docker/Podman runtime detected by signalk-container');
+    }
+
+    await this.startContainer();
+    this.started = true;
+    this.app.debug(`FFmpeg container writing frames to ${this.framePath}`);
+  }
+
+  async startContainer() {
+    const mount = await this.resolveFrameMount();
+    const { image, tag } = resolveImageAndTag(this.options.ffmpeg_container_image);
+    const frameEvery = Math.max(1, this.options.detection_interval || 1);
+
+    await this.containers.ensureRunning(
+      CONTAINER_NAME,
+      {
+        image,
+        tag,
+        restart: 'unless-stopped',
+        resources: {
+          cpus: 0.75,
+          memory: '256m',
+          memorySwap: '256m',
+          pidsLimit: 100
+        },
+        command: [
+          '-nostdin',
+          '-hide_banner',
+          '-loglevel',
+          'warning',
+          '-rtsp_transport',
+          'tcp',
+          '-i',
+          this.rtspUrl,
+          '-an',
+          '-vf',
+          `fps=1/${frameEvery}`,
+          '-q:v',
+          '2',
+          '-update',
+          '1',
+          '-y',
+          mount.containerFramePath
+        ],
+        ...mount.config
+      },
+      {
+        pluginId: 'signalk-forward-watch',
+        pluginVersion: PLUGIN_VERSION,
+        onContainerLog: (line) => this.app.debug(`[ffmpeg-container] ${line}`),
+        onContainerLogStartTail: 25
+      }
+    );
+  }
+
+  async resolveFrameMount() {
+    const configPath = this.app.config && this.app.config.configPath;
+    if (!configPath) {
+      throw new Error('Signal K config root is unavailable; container FFmpeg mode requires app.config.configPath');
+    }
+
+    const relativeFramePath = path.relative(configPath, this.framePath);
+    if (!relativeFramePath || relativeFramePath.startsWith('..') || path.isAbsolute(relativeFramePath)) {
+      throw new Error(`Forward Watch frame path is outside the Signal K config root: ${this.framePath}`);
+    }
+
+    return {
+      config: { signalkConfigRootMount: CONFIG_ROOT_MOUNT },
+      containerFramePath: path.posix.join(CONFIG_ROOT_MOUNT, toPosix(relativeFramePath))
+    };
+  }
+
+  async grabFrame() {
+    if (!this.started) return null;
+
+    let stat;
+    try {
+      stat = fs.statSync(this.framePath);
+    } catch (err) {
+      this.app.debug(`FFmpeg container has not produced a frame yet: ${err.message}`);
+      return null;
+    }
+
+    const ageMs = Date.now() - stat.mtimeMs;
+    if (ageMs > this.frameMaxAgeMs) {
+      this.app.debug(`FFmpeg container frame is stale (${Math.round(ageMs / 1000)}s old)`);
+      await this.restartStaleContainer();
+      return null;
+    }
+
+    return this.framePath;
+  }
+
+  async restartStaleContainer() {
+    if (this.stopped || !this.containers || !this.rtspUrl) return;
+
+    if (!this.restartPromise) {
+      this.restartPromise = (async () => {
+        this.app.debug('Restarting FFmpeg container because frame output is stale');
+        this.started = false;
+
+        try {
+          await this.containers.stop(CONTAINER_NAME);
+        } catch (err) {
+          this.app.debug(`Failed to stop stale FFmpeg container: ${err.message}`);
+        }
+
+        if (this.stopped) return;
+
+        await this.startContainer();
+        this.started = true;
+        this.app.debug(`FFmpeg container restarted, writing frames to ${this.framePath}`);
+      })().finally(() => {
+        this.restartPromise = null;
+      });
+    }
+
+    await this.restartPromise;
+  }
+
+  stop() {
+    this.stopped = true;
+    this.started = false;
+    if (!this.containers) return;
+    this.containers.stop(CONTAINER_NAME).catch((err) => {
+      this.app.debug(`Failed to stop FFmpeg container: ${err.message}`);
+    });
+  }
+}
+
+function toPosix(value) {
+  return value.split(path.sep).filter(Boolean).join('/');
+}
+
+function resolveImageAndTag(imageValue) {
+  let image = imageValue || 'lscr.io/linuxserver/ffmpeg';
+  let tag = 'latest';
+  const lastSlash = image.lastIndexOf('/');
+  const lastColon = image.lastIndexOf(':');
+
+  if (lastColon > lastSlash) {
+    tag = image.slice(lastColon + 1);
+    image = image.slice(0, lastColon);
+  }
+
+  return { image, tag };
+}
+
+module.exports = ContainerRtspGrabber;


### PR DESCRIPTION
## Summary

This adds an optional FFmpeg execution mode for containerized Signal K deployments.

- keeps the existing local `fluent-ffmpeg` grabber as the default
- adds a persistent managed FFmpeg sidecar via `signalk-container.ensureRunning()`
- mounts the Signal K config root with `signalkConfigRootMount` so the container can write frames into Forward Watch's plugin data directory
- lets advanced users override the FFmpeg image, including an optional tag in the same field
- injects configured camera credentials into RTSP URLs that do not already include credentials, and redacts passwords in debug logs
- documents the container mode and troubleshooting path

## Testing

- `node --check` on all JavaScript files
- manually tested container mode far enough to verify FFmpeg runs in the managed container and reaches the RTSP endpoint; an initial 401 from a credential-less RTSP URL was addressed by adding credential injection

## Notes

Container mode requires the `signalk-container` plugin and a working Docker/Podman runtime setup. Local FFmpeg mode remains unchanged and is still the default.