### PR TITLE
Fix multiple AIS targets per detection class

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,16 @@ When **Show detections in OpenCPN** is enabled, each detected object is written 
 
 | Detection | Chart label | MMSI |
 |-----------|-------------|------|
-| ship | FW-SHIP (confidence%) | 800000001 |
-| boat | FW-BOAT (confidence%) | 800000002 |
-| debris | FW-DEBRIS (confidence%) | 800000003 |
-| buoy | FW-BUOY (confidence%) | 800000004 |
-| kayak | FW-KAYAK (confidence%) | 800000005 |
-| log | FW-LOG (confidence%) | 800000006 |
+| ship | FW-SHIP-1..99 (confidence%) | 800000001, 800000011, ... |
+| boat | FW-BOAT-1..99 (confidence%) | 800000002, 800000012, ... |
+| debris | FW-DEBRIS-1..99 (confidence%) | 800000003, 800000013, ... |
+| buoy | FW-BUOY-1..99 (confidence%) | 800000004, 800000014, ... |
+| kayak | FW-KAYAK-1..99 (confidence%) | 800000005, 800000015, ... |
+| log | FW-LOG-1..99 (confidence%) | 800000006, 800000016, ... |
 
-Each class uses a fixed MMSI so the same target updates in place on the chart rather than spawning new ones on every detection cycle.
+The final MMSI digit identifies the detection class, preserving the original single-target values for the first object of each class. Simultaneous detections of the same class are sorted left-to-right in the camera frame and assigned slots 1-99, so multiple boats can appear as separate chart targets instead of overwriting the same fake vessel.
+
+Forward Watch clears virtual AIS targets that are no longer detected on the next detection cycle. It removes only the Signal K paths it publishes for its own fake MMSI contexts, so the chart stays aligned with the current AI detections.
 
 ### OpenCPN (Signal K connection)
 

--- a/index.js
+++ b/index.js
@@ -139,6 +139,7 @@ module.exports = function(app) {
     stop: function() {
       app.debug('Stopping Forward Watch plugin');
       if (this.interval) clearInterval(this.interval);
+      if (this.ocpnOutput) this.ocpnOutput.stop();
       if (this.grabber) this.grabber.stop();
       if (this.detector) this.detector.terminate();
     }

--- a/plugin/opencpn-output.js
+++ b/plugin/opencpn-output.js
@@ -1,15 +1,18 @@
 // Writes forward watch detections into Signal K as fake vessels
 // OpenCPN reads them via its existing Signal K connection and displays them as AIS targets
 
-// Fake MMSIs — use range 800000001-800000006 (won't conflict with real vessels)
-const CLASS_MMSI = {
-  ship:   'urn:mrn:imo:mmsi:800000001',
-  boat:   'urn:mrn:imo:mmsi:800000002',
-  debris: 'urn:mrn:imo:mmsi:800000003',
-  buoy:   'urn:mrn:imo:mmsi:800000004',
-  kayak:  'urn:mrn:imo:mmsi:800000005',
-  log:    'urn:mrn:imo:mmsi:800000006'
+// Fake MMSIs keep the detection class in the final digit, preserving the
+// original single-target values for slot 1 (boat = 800000002, etc.).
+const CLASS_MMSI_DIGIT = {
+  ship:   1,
+  boat:   2,
+  debris: 3,
+  buoy:   4,
+  kayak:  5,
+  log:    6
 };
+const MMSI_PREFIX = 800000000;
+const MAX_TARGETS_PER_CLASS = 99;
 
 const CLASS_LABEL = {
   ship:   'FW-SHIP',
@@ -20,9 +23,18 @@ const CLASS_LABEL = {
   log:    'FW-LOG'
 };
 
+const PLUGIN_ID = 'signalk-forward-watch';
+const CLEAR_VALUES = [
+  { path: 'navigation.position', value: null },
+  { path: 'name', value: null },
+  { path: 'navigation.courseOverGroundTrue', value: null },
+  { path: 'navigation.speedOverGround', value: null }
+];
+
 class OpenCPNOutput {
   constructor(app) {
     this.app = app;
+    this.activeContexts = new Set();
   }
 
   sendDetections(detections) {
@@ -32,11 +44,13 @@ class OpenCPNOutput {
       typeof d.position.longitude === 'number'
     );
 
-    for (const d of withPos) {
-      const context = CLASS_MMSI[d.class_name];
-      if (!context) continue;
+    const targets = assignTargetSlots(withPos);
+    const currentContexts = new Set(targets.map(target => target.context));
 
-      this.app.handleMessage('signalk-forward-watch', {
+    for (const target of targets) {
+      const { detection: d, context, label } = target;
+
+      this.app.handleMessage(PLUGIN_ID, {
         context: `vessels.${context}`,
         updates: [{
           values: [
@@ -49,7 +63,7 @@ class OpenCPNOutput {
             },
             {
               path: 'name',
-              value: `${CLASS_LABEL[d.class_name]} (${Math.round(d.confidence * 100)}%)`
+              value: `${label} (${Math.round(d.confidence * 100)}%)`
             },
             {
               path: 'navigation.courseOverGroundTrue',
@@ -63,9 +77,62 @@ class OpenCPNOutput {
         }]
       });
 
-      this.app.debug(`OpenCPN: ${d.class_name} → ${context} at ${d.position.latitude.toFixed(4)},${d.position.longitude.toFixed(4)}`);
+      this.app.debug(`OpenCPN: ${label} → ${context} at ${d.position.latitude.toFixed(4)},${d.position.longitude.toFixed(4)}`);
     }
+
+    for (const context of this.activeContexts) {
+      if (!currentContexts.has(context)) this.clearTarget(context);
+    }
+
+    this.activeContexts = currentContexts;
   }
+
+  stop() {
+    for (const context of this.activeContexts) {
+      this.clearTarget(context);
+    }
+    this.activeContexts.clear();
+  }
+
+  clearTarget(context) {
+    this.app.handleMessage(PLUGIN_ID, {
+      context: `vessels.${context}`,
+      updates: [{
+        values: CLEAR_VALUES
+      }]
+    });
+
+    this.app.debug(`OpenCPN: cleared ${context}`);
+  }
+}
+
+function assignTargetSlots(detections) {
+  const byClass = new Map();
+
+  for (const detection of detections) {
+    if (!CLASS_MMSI_DIGIT[detection.class_name]) continue;
+    const list = byClass.get(detection.class_name) || [];
+    list.push(detection);
+    byClass.set(detection.class_name, list);
+  }
+
+  const targets = [];
+  for (const [className, classDetections] of byClass.entries()) {
+    classDetections
+      .sort((a, b) => a.cx - b.cx)
+      .slice(0, MAX_TARGETS_PER_CLASS)
+      .forEach((detection, index) => {
+        const slot = index + 1;
+        const mmsi = MMSI_PREFIX + (index * 10) + CLASS_MMSI_DIGIT[className];
+        targets.push({
+          detection,
+          context: `urn:mrn:imo:mmsi:${mmsi}`,
+          label: `${CLASS_LABEL[className]}-${slot}`
+        });
+      });
+  }
+
+  return targets;
 }
 
 module.exports = OpenCPNOutput;


### PR DESCRIPTION
## Summary

This fixes duplicate fake AIS identities when Forward Watch detects multiple objects of the same class in one frame.

- assigns each simultaneous detection of the same class to a separate fake MMSI
- preserves the original single-target MMSI values for the first object of each class, e.g. first boat remains `800000002`
- uses the final MMSI digit as the detection class marker and increments the preceding digits for additional targets
- sorts same-class detections left-to-right in the camera frame before assigning slots
- updates the OpenCPN/AIS documentation table

## Testing

- `node --check` on all JavaScript files
- local smoke test with 11 boat detections: first target uses `800000002`, eleventh uses `800000102`

## Notes

The `next` branch remains available in the fork for combined testing with the FFmpeg container branch.