### PR TITLE
Fix headingTrue unit conversion for target positioning

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,8 @@ module.exports = function(app) {
           // Get boat position from Signal K
           const boatLat = app.getSelfPath('navigation.position.value.latitude') || null;
           const boatLon = app.getSelfPath('navigation.position.value.longitude') || null;
-          const boatHeading = app.getSelfPath('navigation.headingTrue.value') || 0;
+          const headingTrue = app.getSelfPath('navigation.headingTrue.value');
+          const boatHeading = typeof headingTrue === 'number' ? radiansToDegrees(headingTrue) : 0;
 
           // Enrich detections with GPS position
           const enriched = detections.map(d => {
@@ -146,3 +147,7 @@ module.exports = function(app) {
 
   return plugin;
 };
+
+function radiansToDegrees(value) {
+  return value * 180 / Math.PI;
+}


### PR DESCRIPTION
## Summary

- Convert Signal K `navigation.headingTrue` from radians to degrees before passing it to the GPS target position calculator.

## Root Cause

Signal K stores `navigation.headingTrue` in radians, but `GpsCalculator` expects a heading in degrees. A heading such as `Math.PI` radians was interpreted as roughly `3.14` degrees instead of `180` degrees, causing virtual AIS targets to be placed in the wrong direction.

## Validation

- Tested from the integration branch `next`.
- `rg --files -g '*.js' | xargs -n 1 node --check`
- Confirmed the PR diff against `upstream/main` only changes `index.js` for the unit conversion.
